### PR TITLE
Adjust validate and format more than 11 length

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,9 +75,9 @@ export function format(raw: String): String {
     if (!isString(raw)) {
         throw new Error(`CPF.format Error\nExpected String but instead got ${typeof raw}`);
     }
-
-    const regex = /^(\d{3})(\d{3})(\d{3})(\d{2})$/;
-    return strip(parse(raw)).replace(regex, '$1.$2.$3-$4');
+    const newRaw = strip(parse(raw)).substr(0, 11);
+    const regex = /^(\d{3})(\d{3})(\d{3})(\d{2})*$/;
+    return newRaw.replace(regex, '$1.$2.$3-$4');
 }
 
 /**
@@ -145,9 +145,8 @@ export function validate(raw: String): Boolean {
 
     // Get the Array<Number> for the CPF's digits
     const digits = transform(strip(parse(raw)));
-
     // If length is not 11, CPF is not valid!
-    if (digits.length !== 11) {
+    if (digits.length !== 11 || strip(raw).length !== 11) {
         return false;
     }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -57,6 +57,14 @@ describe('CPF module', () => {
             expect(output).to.equal(expected);
         });
 
+        it('should format a CPF string with more than 11 length', () => {
+            const expected = '101.010.101-01';
+            const input = '10101010101090909';
+            const output = CPF.format(input);
+
+            expect(output).to.equal(expected);
+        });
+
         it('shouldnt format non-cpf strings', () => {
             const expected = '';
             const input = 'lorem ipsum';
@@ -130,6 +138,14 @@ describe('CPF module', () => {
         it('should return false for a invalid CPF', () => {
             const expected = false;
             const input = '45260864281';
+            const output = CPF.validate(input);
+
+            expect(output).to.equal(expected);
+        });
+
+        it('should return false for a invalid CPF length', () => {
+            const expected = false;
+            const input = '0123456789000';
             const output = CPF.validate(input);
 
             expect(output).to.equal(expected);


### PR DESCRIPTION
When i passed this CPF: `01234567890000` the component **not formated** my CPF and the validate function **returned true**.
in the validate function I just check string has more than 11 length and return false...
And the format function, i just `substr(0,11)` in the string.